### PR TITLE
Fixed: JSON printing of wrong keypair data

### DIFF
--- a/src/client/common.py
+++ b/src/client/common.py
@@ -15,8 +15,6 @@ import xmltodict
 
 import exceptions
 
-import yaml
-
 requests.packages.urllib3.disable_warnings()
 global_vars = {
     'access_key': None,
@@ -197,8 +195,16 @@ def do_request(method, url, headers=None):
                     verify=global_vars['is_secure'])
 
         if resp.status_code >= 400:
-            print 'Exception %s thrown!!! Status code:' % resp.status_code
-            print 'Error content: ', json.dumps(json.loads(resp.content), indent=4, sort_keys=True)
+            #print resp.content
+            print 'Exception %s thrown! Status code:' % resp.status_code
+            try:
+                print 'Error content: ', json.dumps(json.loads(resp.content),
+                                                    indent=4, sort_keys=True)
+            except:
+                resp_dict = dict()
+                resp_ordereddict = xmltodict.parse(resp.content)
+                resp_dict = yaml.safe_load(json.dumps(resp_ordereddict))
+                print json.dumps(resp_dict, indent=4, sort_keys=True)
             print 'Refer to, jcs --help'
             if resp.status_code == 400:
                 raise exceptions.HTTP400()
@@ -213,10 +219,14 @@ def do_request(method, url, headers=None):
                 resp_dict = json.loads(response)
                 print json.dumps(resp_dict, indent=4, sort_keys=True)
         except:
+            #print response
             resp_dict = dict()
             resp_ordereddict = xmltodict.parse(response)
-            resp_dict = yaml.safe_load(json.dumps(resp_ordereddict))
-            print json.dumps(resp_dict, indent=4, sort_keys=True)
+            resp_json_string = json.dumps(resp_ordereddict, indent=4,
+                                          sort_keys=True)
+            # handle the case of keypair data
+            resp_json_string = resp_json_string.replace("\\n", "\n")
+            print (resp_json_string)
         print "\n\nRequest successfully executed !"
         return resp_dict
     else:

--- a/src/client/common.py
+++ b/src/client/common.py
@@ -203,8 +203,7 @@ def do_request(method, url, headers=None):
             except:
                 resp_dict = dict()
                 resp_ordereddict = xmltodict.parse(resp.content)
-                resp_dict = yaml.safe_load(json.dumps(resp_ordereddict))
-                print json.dumps(resp_dict, indent=4, sort_keys=True)
+                print json.dumps(resp_ordereddict, indent=4, sort_keys=True)
             print 'Refer to, jcs --help'
             if resp.status_code == 400:
                 raise exceptions.HTTP400()


### PR DESCRIPTION
```
Handled the case of json skipping newline characters and writing
\n in place of the character. This will happen only in case of
keypair hence other services are unaffected

Also took care of parsing error coming in xml to be shown as json
for the services that are returning xml string
```
