### PR TITLE
Default all endpoint variables to production endpoints

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -125,8 +125,10 @@ Once you have installed this library in your computer (systemwide or in a virtua
     # Set up client with parameters as sourced environment variables
     common.setup_client_from_env_vars()
     
-    # OR alternatively set up client by passing required parameters
-    #common.setup_client('myaccesskey', 'mysecretkey', 'mycomputeurl', 'myvpcurl')
+    # OR alternatively set up client by passing required parameters. Optional
+    # key-value argument keys are: 'iam_url', 'dss_url' and 'rds_url'
+    common.setup_client('myaccesskey', 'mysecretkey', 'mycomputeurl', 'myvpcurl',
+        iam_url="http://localhost')
     
     print cloud.describe_snapshots()
 

--- a/src/client/cli.py
+++ b/src/client/cli.py
@@ -87,6 +87,7 @@ def main(argv=sys.argv):
         print "               jcs iam ActionName --Param1 <value> --Param2 <value>"
         print "               jcs iam --help"
         print "               jcs iam ActionName --help"
+        print "               jcs rds --help"
         print "Service argument can be 'iam', 'rds', 'compute', 'vpc' or 'dss'"
         print "If '--curl' is specified, only curl request input will be"
         print "produced. No request will be made"

--- a/src/client/common.py
+++ b/src/client/common.py
@@ -14,6 +14,7 @@ import urllib as ul
 import xmltodict
 
 import exceptions
+import endpoints
 
 #requests.packages.urllib3.disable_warnings()
 global_vars = {
@@ -64,13 +65,18 @@ def setup_client(access_key, secret_key, compute_url, vpc_url, **other_params):
 
 def setup_client_from_env_vars():
     """Populates client from environment variables."""
-    setup_client(os.environ.get('ACCESS_KEY'),
-                          os.environ.get('SECRET_KEY'),
-                          os.environ.get('COMPUTE_URL'),
-                          os.environ.get('VPC_URL'),
-                          dss_url=os.environ.get('DSS_URL'),
-                          rds_url=os.environ.get('RDS_URL'),
-                          iam_url=os.environ.get('IAM_URL'))
+    # TODO(rushiagr): add logging here when we're using production endpoints?
+    # E.g. "Using default production endpoint <endpoint> for IAM as IAM_URL
+    # environment variable is not specified"
+    # TODO(rushiagr): remove special treatment to compute and vpc urls
+    setup_client(
+        os.environ.get('ACCESS_KEY'),
+        os.environ.get('SECRET_KEY'),
+        os.environ.get('COMPUTE_URL', endpoints.production['COMPUTE_URL']),
+        os.environ.get('VPC_URL', endpoints.production['VPC_URL']),
+        dss_url=os.environ.get('DSS_URL', endpoints.production['DSS_URL']),
+        rds_url=os.environ.get('RDS_URL', endpoints.production['RDS_URL']),
+        iam_url=os.environ.get('IAM_URL', endpoints.production['IAM_URL']))
 
 def _get_utf8_value(value):
     """Get the UTF8-encoded version of a value."""

--- a/src/client/endpoints.py
+++ b/src/client/endpoints.py
@@ -1,0 +1,7 @@
+production = {
+    'COMPUTE_URL': 'https://compute.ind-west-1.jiocloudservices.com/',
+    'VPC_URL': 'https://vpc.ind-west-1.jiocloudservices.com/',
+    'IAM_URL': 'https://iam.ind-west-1.jiocloudservices.com/',
+    'RDS_URL': 'https://rds.ind-west-1.jiocloudservices.com/',
+    'DSS_URL': 'https://dss.ind-west-1.jiocloudservices.com/',
+}


### PR DESCRIPTION
This will mean if the user doesn't specify any endpoint URL as env vars,
we'll take him/her to production endpoints. So mandatory environment
variables will only be ACCESS_KEY and SECRET_KEY.
