### PR TITLE
Add pycrypto dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ xmltodict
 six
 pyyaml
 Crypto
+pycrypto

--- a/setup.py
+++ b/setup.py
@@ -65,7 +65,7 @@ setup(
     ],
     install_requires=[
         # eg: 'aspectlib==1.1.1', 'six>=1.7',
-        'requests', 'xmltodict', 'six', 'pyyaml', 'Crypto'
+        'requests', 'xmltodict', 'six', 'pyyaml', 'Crypto', 'pycrypto'
     ],
     extras_require={
         # eg:


### PR DESCRIPTION
People were facing problems even after adding 'crypto' package as a
dependency. The issue gets resolved when one installs pycrypto. This is
exactly what we're doing in this patch.
